### PR TITLE
feat: クリップボード履歴UI改修（バグ修正+機能追加+テスト）

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ uuid = { version = "1", features = ["v4"] }
 # ウィンドウ管理（eframeの依存、any_thread設定用に明示指定）
 winit = "0.30"
 
+# 画像デコード（クリップボード履歴のサムネイル表示用）
+image = { version = "0.25", default-features = false, features = ["png"] }
+
 # システムトレイアイコン（tauri-apps製）
 tray-icon = "0.19"
 
@@ -41,6 +44,7 @@ global-hotkey = "0.7"
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_System_Console",
     "Win32_System_DataExchange",
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,155 @@
+# lanch-app 引き継ぎ資料 (2026-03-13)
+
+## 現状サマリ
+
+lanch-app は Rust 製 Windows デスクトップアプリ（Alfred/Raycast 風ランチャー）。
+翻訳・Markdown整形・クリップボード履歴の3機能を持つ。
+
+クリップボード履歴UIの改修中に2つのバグが残っている。
+
+---
+
+## 未解決バグ（優先度順）
+
+### BUG-1: 画像エントリ選択時にクラッシュ
+
+**症状**: Ctrl+Shift+V でクリップボード履歴ポップアップを開き、↑↓キーで Image エントリを選択すると、アプリがクラッシュ（ウィンドウ消失）する。テキストエントリの選択は正常動作。
+
+**原因の推測**: `src/clipboard_ui.rs` の `load_image_texture()` (L144-178) で `image` クレートの PNG デコード → egui テクスチャ変換時にパニックしている可能性が高い。
+
+- 11.2MB の大きな PNG をデコードしてメモリ上に RGBA 展開するとき、メモリ不足 or unwrap パニック
+- `rgba.dimensions()` が `image` クレートの `GenericImageView` トレイトを要求するが、import が削除済み（warning修正時に消した）。ただしコンパイルは通っているので `to_rgba8()` の戻り値の固有メソッドで解決しているかもしれない
+- `egui::ColorImage::from_rgba_unmultiplied` に渡すバッファサイズが不一致の可能性
+
+**修正方針**:
+1. `load_image_texture()` 内の処理を全て `catch_unwind` で包むか、各ステップを個別に `eprintln!` でログ出力して原因特定
+2. 大きな画像はデコード前にリサイズする（image クレートの `resize` を使う）
+3. 最低限、画像デコード失敗時にクラッシュせず「読み込み失敗」メッセージを表示するようにする
+
+**関連ファイル**: `src/clipboard_ui.rs` L144-178, L270-300
+
+### BUG-2: ~~EventLoop 再作成エラー~~ (修正済み・未検証)
+
+**症状**: Ctrl+Shift+V を2回目以降押すと `winit EventLoopError: EventLoop can't be recreated` エラー。
+
+**対応済み内容**: `tray.rs` で `thread::spawn` + `eframe::run_native` の代わりに `spawn_self(&["--clipboard-history"])` で別プロセス起動するように変更済み。`main.rs` に `--clipboard-history` モード追加済み。
+
+**検証状況**: BUG-1 のクラッシュで2回目起動を十分テストできていない。テキストのみの履歴で2回目起動が動くか確認すること。
+
+---
+
+## 直近で完了した変更（未コミット）
+
+### 1. 選択ハイライトを黄色に変更 ✅
+- `src/clipboard_ui.rs` L367-368
+- 背景: `Color32::from_rgba_premultiplied(250, 227, 80, 40)` (半透明黄色)
+- ボーダー/テキスト: `Color32::from_rgb(250, 227, 80)`
+
+### 2. 水平分割レイアウト（リスト | 詳細パネル）✅
+- `src/clipboard_ui.rs` 全体
+- 左45%: エントリリスト、右55%: 詳細パネル
+- ウィンドウサイズ: 600x500 → 1100x600
+- シングルクリック → 選択のみ（詳細表示）、ダブルクリック → コピー＆閉じる
+
+### 3. テキスト詳細表示 ✅
+- 1000文字以上は `...` で切り詰め
+- JSON はモノスペースフォントで表示
+- 定数 `DETAIL_TEXT_MAX_CHARS = 1000`
+
+### 4. 画像サムネイル表示 ❌ (BUG-1)
+- `image` クレート追加済み (`Cargo.toml`: `image = { version = "0.25", features = ["png"] }`)
+- `load_image_texture()` 実装済みだがクラッシュする
+- 定数 `DETAIL_IMAGE_MIN_SIZE = 500.0`
+
+### 5. 別プロセス起動 ✅ (BUG-2対策)
+- `main.rs`: `--clipboard-history` CLI引数追加
+- `tray.rs`: `spawn_self(&["--clipboard-history"])` に変更
+- `clipboard_store::ClipboardStore::new(7)` でファイルから読み直す
+
+### 6. ファイルログ出力 ✅
+- `main.rs` の `init_logging()`: `~/.lanch-app/lanch-app.log` に stderr リダイレクト
+- Win32 `SetStdHandle` で stderr をファイルハンドルに差し替え
+- ローテーション: 2日超 or 1MB超で `.log.old` に、2日超の `.log.old` は削除
+- `Cargo.toml`: `Win32_System_Console` feature 追加済み
+
+---
+
+## ファイル構成と責務
+
+```
+src/
+├── main.rs              # エントリポイント、CLI引数解析、ログ初期化
+├── tray.rs              # システムトレイ、ホットキー登録、メニュー
+├── clipboard_ui.rs      # クリップボード履歴 egui ポップアップ ★修正対象
+├── clipboard_store.rs   # 履歴ストレージ（JSON index + blobs/）
+├── clipboard_history.rs # Win32 クリップボード監視 + PNG エンコーダー
+├── clipboard.rs         # クリップボード操作ヘルパー
+├── config.rs            # 設定ファイル管理
+├── formatter.rs         # Markdown整形（API/CLI ハイブリッド）
+├── translator.rs        # 翻訳機能
+├── popup.rs             # 翻訳ポップアップUI
+├── notification.rs      # 通知ヘルパー
+└── lang.rs              # 言語検出
+```
+
+## ストレージ構造
+
+```
+~/.lanch-app/
+├── config.json
+├── lanch-app.log           # ← 新規追加
+├── lanch-app.log.old       # ← 新規追加
+└── clipboard-history/
+    ├── index.json          # エントリメタデータ
+    └── blobs/              # 画像PNG
+        ├── Image 2026-03-13 17-56-42.png
+        └── ...
+```
+
+## 主要な型
+
+- `ClipboardEntry`: id, timestamp, entry_type(Text/Image/Json), text_content, blob_file, preview, size_bytes
+- `ClipboardStore`: entries Vec, store_dir, search(), rotate(), blob_path()
+- `SharedStore` = `Arc<Mutex<ClipboardStore>>`
+- `ClipboardHistoryPopup`: eframe::App 実装、image_cache: HashMap<String, TextureHandle>
+
+## テスト
+
+84テスト全パス（`cargo test`）。clipboard_store(30+), clipboard_history(15), config(12), formatter(14), lang(6) のユニットテスト。
+
+## 設計原則（CLAUDE.md）
+
+SOLID, KISS, YAGNI, DRY
+
+## ビルド・実行
+
+```powershell
+# ビルド＆起動（PowerShell）
+cargo build; if ($?) { Start-Process .\target\debug\lanch-app.exe }
+
+# テスト
+cargo test
+
+# ログ確認
+Get-Content ~\.lanch-app\lanch-app.log -Tail 50
+```
+
+## GitHub Issues（未クローズ）
+
+- #1 テスト
+- #2 自動起動
+- #3 ホットキー競合
+- #4 WinRT通知
+- #5 CLIモード検証
+- #6 設定クリーンアップ
+- #7 ClipboardHistory（未作成）
+
+---
+
+## Claude Code への依頼事項
+
+1. **BUG-1 修正**: 画像選択時のクラッシュを直す。`load_image_texture()` でパニックしないようにし、大画像はリサイズしてからテクスチャ化する。ログ (`~/.lanch-app/lanch-app.log`) を確認してクラッシュ原因を特定すること。
+2. **BUG-2 検証**: テキストのみでの2回目起動を確認。
+3. **warning 0 を維持**: `cargo build` で warning が出ないようにする。
+4. **テスト維持**: `cargo test` で 84 テスト全パスを維持。
+5. **コミット**: 全修正完了後に git commit & push。

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -344,6 +344,35 @@ fn send_key(_key: u8) -> bool {
     false
 }
 
+/// 指定ウィンドウにフォーカスを戻してCtrl+Vをシミュレートする
+#[cfg(windows)]
+pub fn restore_focus_and_paste(hwnd: isize) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::SetForegroundWindow;
+
+    unsafe {
+        SetForegroundWindow(hwnd as _);
+    }
+    thread::sleep(Duration::from_millis(100));
+    let _ = send_ctrl_combo(VK_V);
+}
+
+#[cfg(not(windows))]
+pub fn restore_focus_and_paste(_hwnd: isize) {}
+
+/// 現在のフォアグラウンドウィンドウのハンドルを取得する
+#[cfg(windows)]
+pub fn get_foreground_hwnd() -> isize {
+    use windows_sys::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
+    unsafe { GetForegroundWindow() as isize }
+}
+
+#[cfg(not(windows))]
+pub fn get_foreground_hwnd() -> isize {
+    0
+}
+
+const VK_V: u8 = 0x56;
+
 /// 選択テキストをコピーしてクリップボードから読み取る
 ///
 /// 1. 既存クリップボードを保存

--- a/src/clipboard_ui.rs
+++ b/src/clipboard_ui.rs
@@ -10,8 +10,11 @@
 
 use eframe::egui;
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
+use crate::clipboard;
 use crate::clipboard_history::SharedStore;
 use crate::clipboard_store::{ClipboardEntry, EntryType};
 
@@ -43,10 +46,12 @@ pub struct ClipboardHistoryPopup {
     selected_index: i32,
     /// 画像テクスチャのキャッシュ (blob_file名 → TextureHandle)
     image_cache: HashMap<String, egui::TextureHandle>,
+    /// エントリ選択によるペーストが必要か（ウィンドウ終了後に参照）
+    paste_after_close: Arc<AtomicBool>,
 }
 
 impl ClipboardHistoryPopup {
-    pub fn new(store: SharedStore) -> Self {
+    pub fn new(store: SharedStore, paste_after_close: Arc<AtomicBool>) -> Self {
         let mut popup = Self {
             store,
             search_query: String::new(),
@@ -60,6 +65,7 @@ impl ClipboardHistoryPopup {
             selected_entry_id: None,
             selected_index: -1,
             image_cache: HashMap::new(),
+            paste_after_close,
         };
         popup.refresh_results();
         popup
@@ -93,13 +99,19 @@ impl ClipboardHistoryPopup {
                 if let Some(ref blob_file) = entry.blob_file {
                     if let Ok(store) = self.store.lock() {
                         let path = store.blob_path(blob_file);
-                        if let Ok(data) = std::fs::read(&path) {
-                            // PNG → arboard::ImageData への変換は複雑なので
-                            // ファイルパスをテキストとしてコピー（暫定）
-                            if let Ok(mut cb) = arboard::Clipboard::new() {
-                                let _ = cb.set_text(path.to_string_lossy().as_ref());
+                        if let Ok(png_data) = std::fs::read(&path) {
+                            if let Ok(img) = image::load_from_memory_with_format(&png_data, image::ImageFormat::Png) {
+                                let rgba = img.to_rgba8();
+                                let (w, h) = (rgba.width() as usize, rgba.height() as usize);
+                                let img_data = arboard::ImageData {
+                                    width: w,
+                                    height: h,
+                                    bytes: std::borrow::Cow::Owned(rgba.into_raw()),
+                                };
+                                if let Ok(mut cb) = arboard::Clipboard::new() {
+                                    let _ = cb.set_image(img_data);
+                                }
                             }
-                            let _ = data; // suppress warning
                         }
                     }
                 }
@@ -337,10 +349,11 @@ impl eframe::App for ClipboardHistoryPopup {
             return;
         }
 
-        // エントリ選択後の処理
+        // エントリ選択後の処理: コピー → ウィンドウ閉じる → フォーカス復元 & ペースト
         if let Some(ref id) = self.selected_entry_id.take() {
             if let Some(entry) = self.display_entries.iter().find(|e| &e.id == id) {
                 self.copy_entry_to_clipboard(entry);
+                self.paste_after_close.store(true, Ordering::SeqCst);
                 ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                 return;
             }
@@ -441,15 +454,18 @@ impl eframe::App for ClipboardHistoryPopup {
 
                 // ===== 水平分割レイアウト: リスト(左) | 詳細パネル(右) =====
                 let available_width = ui.available_width();
+                let available_height = ui.available_height();
                 let list_width = available_width * 0.45; // 左45%
-                let _detail_width = available_width * 0.55; // 右55%
 
                 let scroll_to_index = self.selected_index;
 
                 ui.horizontal(|ui| {
+                    ui.set_min_height(available_height);
+
                     // --- 左パネル: エントリリスト ---
                     ui.vertical(|ui| {
                         ui.set_width(list_width);
+                        ui.set_min_height(available_height);
 
                         egui::ScrollArea::vertical()
                             .id_salt("entry_list")
@@ -626,6 +642,7 @@ impl eframe::App for ClipboardHistoryPopup {
 
                     // --- 右パネル: 詳細表示 ---
                     ui.vertical(|ui| {
+                        ui.set_min_height(available_height);
                         self.render_detail_panel(ui, ctx);
                     });
                 });
@@ -638,6 +655,11 @@ impl eframe::App for ClipboardHistoryPopup {
 
 /// クリップボード履歴ポップアップを表示する
 pub fn show_clipboard_history(store: SharedStore) -> Result<(), Box<dyn std::error::Error>> {
+    // ポップアップ起動前のフォアグラウンドウィンドウを記憶
+    let previous_hwnd = clipboard::get_foreground_hwnd();
+    let paste_flag = Arc::new(AtomicBool::new(false));
+    let paste_flag_clone = paste_flag.clone();
+
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([1100.0, 600.0])
@@ -658,9 +680,14 @@ pub fn show_clipboard_history(store: SharedStore) -> Result<(), Box<dyn std::err
         options,
         Box::new(move |cc| {
             setup_japanese_fonts(&cc.egui_ctx);
-            Ok(Box::new(ClipboardHistoryPopup::new(store)) as Box<dyn eframe::App>)
+            Ok(Box::new(ClipboardHistoryPopup::new(store, paste_flag_clone)) as Box<dyn eframe::App>)
         }),
     )?;
+
+    // ウィンドウ終了後: エントリ選択があった場合は元ウィンドウにフォーカスを戻してペースト
+    if paste_flag.load(Ordering::SeqCst) && previous_hwnd != 0 {
+        clipboard::restore_focus_and_paste(previous_hwnd);
+    }
 
     Ok(())
 }

--- a/src/clipboard_ui.rs
+++ b/src/clipboard_ui.rs
@@ -1,13 +1,15 @@
 // clipboard_ui.rs - クリップボード履歴 検索UI
 //
 // 責務:
-// - egui ポップアップで履歴を表示（検索窓 + ページャー付きリスト）
+// - egui ポップアップで履歴を表示（検索窓 + ページャー付きリスト + 詳細パネル）
 // - キーワード検索（テキスト内容 + 日付）
 // - 100件ごとのページャー（「...see more」で次のページ）
 // - 上下キーでエントリ選択、Enterでコピー&閉じる
 // - エントリ選択でクリップボードにコピー & ウィンドウを閉じる
+// - 選択中エントリの詳細表示（テキスト全文 / 画像サムネイル）
 
 use eframe::egui;
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use crate::clipboard_history::SharedStore;
@@ -15,6 +17,9 @@ use crate::clipboard_store::{ClipboardEntry, EntryType};
 
 /// 1ページあたりの表示件数
 const ITEMS_PER_PAGE: usize = 100;
+
+/// 詳細パネルのテキスト表示最大文字数
+const DETAIL_TEXT_MAX_CHARS: usize = 1000;
 
 /// クリップボード履歴ポップアップ
 pub struct ClipboardHistoryPopup {
@@ -36,6 +41,8 @@ pub struct ClipboardHistoryPopup {
     selected_entry_id: Option<String>,
     /// キーボード選択中のインデックス（-1 = 未選択 / 検索窓にフォーカス）
     selected_index: i32,
+    /// 画像テクスチャのキャッシュ (blob_file名 → TextureHandle)
+    image_cache: HashMap<String, egui::TextureHandle>,
 }
 
 impl ClipboardHistoryPopup {
@@ -52,6 +59,7 @@ impl ClipboardHistoryPopup {
             created_at: Instant::now(),
             selected_entry_id: None,
             selected_index: -1,
+            image_cache: HashMap::new(),
         };
         popup.refresh_results();
         popup
@@ -129,6 +137,181 @@ impl ClipboardHistoryPopup {
 
         false
     }
+
+    /// 選択中エントリの画像をロードしてテクスチャキャッシュに登録
+    ///
+    /// 大きな画像はデコード後にリサイズしてからテクスチャ化する。
+    /// デコード失敗時はNoneを返す（パニックしない）。
+    fn load_image_texture(&mut self, ctx: &egui::Context, blob_file: &str) -> Option<egui::TextureHandle> {
+        // キャッシュにあればそれを返す
+        if let Some(handle) = self.image_cache.get(blob_file) {
+            return Some(handle.clone());
+        }
+
+        // blobファイルからPNGデータを読み込み
+        let path = if let Ok(store) = self.store.lock() {
+            store.blob_path(blob_file)
+        } else {
+            return None;
+        };
+
+        let png_data = match std::fs::read(&path) {
+            Ok(data) => data,
+            Err(e) => {
+                eprintln!("[clipboard_ui] 画像ファイル読み込み失敗: {}: {}", path.display(), e);
+                return None;
+            }
+        };
+
+        let (w, h, rgba_buf) = match decode_and_resize_png(&png_data) {
+            Ok(result) => result,
+            Err(e) => {
+                eprintln!("[clipboard_ui] {}: {}", blob_file, e);
+                return None;
+            }
+        };
+
+        let color_image = egui::ColorImage::from_rgba_unmultiplied(
+            [w as usize, h as usize],
+            &rgba_buf,
+        );
+
+        let texture = ctx.load_texture(
+            format!("clipboard_img_{}", blob_file),
+            color_image,
+            egui::TextureOptions::LINEAR,
+        );
+
+        self.image_cache.insert(blob_file.to_string(), texture.clone());
+        Some(texture)
+    }
+
+    /// 詳細パネルを描画する
+    fn render_detail_panel(&mut self, ui: &mut egui::Ui, ctx: &egui::Context) {
+        let hint_color = egui::Color32::from_rgb(108, 112, 134);
+        let fg_color = egui::Color32::from_rgb(205, 214, 244);
+        let accent_color = egui::Color32::from_rgb(137, 180, 250);
+
+        // 選択中のエントリを取得
+        let selected = if self.selected_index >= 0
+            && (self.selected_index as usize) < self.display_entries.len()
+        {
+            Some(self.display_entries[self.selected_index as usize].clone())
+        } else {
+            None
+        };
+
+        match selected {
+            None => {
+                // 未選択時のプレースホルダー
+                ui.vertical_centered(|ui| {
+                    ui.add_space(ui.available_height() / 3.0);
+                    ui.colored_label(
+                        hint_color,
+                        egui::RichText::new("↑↓ キーでエントリを選択\n詳細がここに表示されます")
+                            .size(13.0),
+                    );
+                });
+            }
+            Some(entry) => {
+                // ヘッダー: 種別 + 日時 + サイズ
+                ui.colored_label(
+                    accent_color,
+                    egui::RichText::new(format!(
+                        "{} | {} | {}",
+                        entry.entry_type,
+                        entry.timestamp.format("%Y-%m-%d %H:%M:%S"),
+                        format_size(entry.size_bytes),
+                    ))
+                    .size(11.0),
+                );
+                ui.add_space(8.0);
+                ui.separator();
+                ui.add_space(4.0);
+
+                match entry.entry_type {
+                    EntryType::Text | EntryType::Json => {
+                        // テキスト内容を表示（1000文字超は切り詰め）
+                        egui::ScrollArea::vertical()
+                            .auto_shrink([false; 2])
+                            .show(ui, |ui| {
+                                if let Some(ref text) = entry.text_content {
+                                    let display_text = if text.chars().count() > DETAIL_TEXT_MAX_CHARS {
+                                        let truncated: String = text.chars().take(DETAIL_TEXT_MAX_CHARS).collect();
+                                        format!("{}...", truncated)
+                                    } else {
+                                        text.clone()
+                                    };
+
+                                    // JSONの場合はモノスペースで表示
+                                    let text_style = if entry.entry_type == EntryType::Json {
+                                        egui::RichText::new(&display_text)
+                                            .size(12.0)
+                                            .color(fg_color)
+                                            .family(egui::FontFamily::Monospace)
+                                    } else {
+                                        egui::RichText::new(&display_text)
+                                            .size(12.0)
+                                            .color(fg_color)
+                                    };
+                                    ui.label(text_style);
+
+                                    if text.chars().count() > DETAIL_TEXT_MAX_CHARS {
+                                        ui.add_space(4.0);
+                                        ui.colored_label(
+                                            hint_color,
+                                            egui::RichText::new(format!(
+                                                "({} 文字中 {} 文字を表示)",
+                                                text.chars().count(),
+                                                DETAIL_TEXT_MAX_CHARS,
+                                            ))
+                                            .size(10.0),
+                                        );
+                                    }
+                                } else {
+                                    ui.colored_label(
+                                        hint_color,
+                                        egui::RichText::new("(テキストデータなし)").size(12.0),
+                                    );
+                                }
+                            });
+                    }
+                    EntryType::Image => {
+                        // 画像サムネイルを表示
+                        if let Some(ref blob_file) = entry.blob_file {
+                            let blob_key = blob_file.clone();
+                            if let Some(texture) = self.load_image_texture(ctx, &blob_key) {
+                                let tex_size = texture.size_vec2();
+                                let available = ui.available_size();
+                                let (dw, dh) = calculate_image_display_size(
+                                    tex_size.x, tex_size.y, available.x, available.y,
+                                );
+
+                                egui::ScrollArea::both()
+                                    .auto_shrink([false; 2])
+                                    .show(ui, |ui| {
+                                        ui.image(egui::load::SizedTexture::new(
+                                            texture.id(),
+                                            egui::vec2(dw, dh),
+                                        ));
+                                    });
+                            } else {
+                                ui.colored_label(
+                                    hint_color,
+                                    egui::RichText::new("(画像の読み込みに失敗しました)").size(12.0),
+                                );
+                            }
+                        } else {
+                            ui.colored_label(
+                                hint_color,
+                                egui::RichText::new("(画像ファイルが見つかりません)").size(12.0),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl eframe::App for ClipboardHistoryPopup {
@@ -170,7 +353,7 @@ impl eframe::App for ClipboardHistoryPopup {
             self.refresh_results();
         }
 
-        // --- UI ---
+        // --- カラーテーマ ---
         let bg_color = egui::Color32::from_rgb(30, 30, 46);
         let fg_color = egui::Color32::from_rgb(205, 214, 244);
         let accent_color = egui::Color32::from_rgb(137, 180, 250);
@@ -180,8 +363,10 @@ impl eframe::App for ClipboardHistoryPopup {
         let image_entry_color = egui::Color32::from_rgb(148, 226, 213);
         let border_color = egui::Color32::from_rgb(69, 71, 90);
         let hover_color = egui::Color32::from_rgb(49, 50, 68);
-        let selected_color = egui::Color32::from_rgb(69, 71, 90);
-        let selected_border_color = accent_color;
+        // 選択ハイライト: 黄色系
+        let selected_color = egui::Color32::from_rgba_premultiplied(250, 227, 80, 40);
+        let selected_border_color = egui::Color32::from_rgb(250, 227, 80);
+        let panel_divider_color = egui::Color32::from_rgb(69, 71, 90);
 
         egui::CentralPanel::default()
             .frame(
@@ -254,160 +439,196 @@ impl eframe::App for ClipboardHistoryPopup {
 
                 ui.add_space(4.0);
 
-                // スクロールエリア
+                // ===== 水平分割レイアウト: リスト(左) | 詳細パネル(右) =====
+                let available_width = ui.available_width();
+                let list_width = available_width * 0.45; // 左45%
+                let _detail_width = available_width * 0.55; // 右55%
+
                 let scroll_to_index = self.selected_index;
 
-                egui::ScrollArea::vertical()
-                    .auto_shrink([false; 2])
-                    .show(ui, |ui| {
-                        for (i, entry) in self.display_entries.iter().enumerate() {
-                            let is_selected = self.selected_index == i as i32;
+                ui.horizontal(|ui| {
+                    // --- 左パネル: エントリリスト ---
+                    ui.vertical(|ui| {
+                        ui.set_width(list_width);
 
-                            let (type_icon, type_color) = match entry.entry_type {
-                                EntryType::Text => ("T", text_entry_color),
-                                EntryType::Json => ("J", json_entry_color),
-                                EntryType::Image => ("I", image_entry_color),
-                            };
+                        egui::ScrollArea::vertical()
+                            .id_salt("entry_list")
+                            .auto_shrink([false; 2])
+                            .show(ui, |ui| {
+                                for (i, entry) in self.display_entries.iter().enumerate() {
+                                    let is_selected = self.selected_index == i as i32;
 
-                            let time_str = entry.timestamp.format("%m/%d %H:%M").to_string();
+                                    let (type_icon, type_color) = match entry.entry_type {
+                                        EntryType::Text => ("T", text_entry_color),
+                                        EntryType::Json => ("J", json_entry_color),
+                                        EntryType::Image => ("I", image_entry_color),
+                                    };
 
-                            // エントリ行（クリック可能）
-                            let response = ui
-                                .horizontal(|ui| {
-                                    // 選択インジケーター
+                                    let time_str = entry.timestamp.format("%m/%d %H:%M").to_string();
+
+                                    // エントリ行（クリック可能）
+                                    let response = ui
+                                        .horizontal(|ui| {
+                                            // 選択インジケーター
+                                            if is_selected {
+                                                ui.colored_label(
+                                                    selected_border_color,
+                                                    egui::RichText::new("▸").size(12.0),
+                                                );
+                                            } else {
+                                                ui.add_space(14.0);
+                                            }
+
+                                            // 種別バッジ
+                                            let badge = egui::RichText::new(type_icon)
+                                                .size(10.0)
+                                                .color(egui::Color32::from_rgb(30, 30, 46))
+                                                .strong();
+                                            ui.colored_label(type_color, badge);
+                                            ui.add_space(4.0);
+
+                                            // タイムスタンプ
+                                            ui.colored_label(
+                                                hint_color,
+                                                egui::RichText::new(&time_str).size(10.0),
+                                            );
+
+                                            ui.add_space(4.0);
+
+                                            // プレビュー（折り返さず1行で）
+                                            let preview = if entry.preview.len() > 50 {
+                                                format!(
+                                                    "{}...",
+                                                    entry.preview.chars().take(50).collect::<String>()
+                                                )
+                                            } else {
+                                                entry.preview.clone()
+                                            };
+
+                                            // 選択中は太字 + 黄色テキストで表示
+                                            let text = if is_selected {
+                                                egui::RichText::new(preview)
+                                                    .size(12.0)
+                                                    .strong()
+                                                    .color(selected_border_color)
+                                            } else {
+                                                egui::RichText::new(preview)
+                                                    .size(12.0)
+                                                    .color(fg_color)
+                                            };
+                                            ui.label(text);
+                                        })
+                                        .response;
+
+                                    // 選択中 or ホバー時の背景
                                     if is_selected {
-                                        ui.colored_label(
-                                            accent_color,
-                                            egui::RichText::new("▸").size(12.0),
+                                        // 選択行: 黄色の半透明背景 + 左ボーダー
+                                        ui.painter().rect_filled(
+                                            response.rect,
+                                            2.0,
+                                            selected_color,
                                         );
-                                    } else {
-                                        ui.add_space(14.0);
+                                        // 左側に黄色のバー
+                                        let bar_rect = egui::Rect::from_min_size(
+                                            response.rect.left_top(),
+                                            egui::vec2(3.0, response.rect.height()),
+                                        );
+                                        ui.painter().rect_filled(bar_rect, 1.0, selected_border_color);
+                                    } else if response.hovered() {
+                                        ui.painter().rect_filled(
+                                            response.rect,
+                                            2.0,
+                                            hover_color,
+                                        );
                                     }
 
-                                    // 種別バッジ
-                                    let badge = egui::RichText::new(type_icon)
-                                        .size(10.0)
-                                        .color(egui::Color32::from_rgb(30, 30, 46))
-                                        .strong();
-                                    ui.colored_label(type_color, badge);
-                                    ui.add_space(4.0);
+                                    // クリックで選択（ダブルクリックでコピー）
+                                    if response.clicked() {
+                                        self.selected_index = i as i32;
+                                    }
+                                    if response.double_clicked() {
+                                        self.selected_entry_id = Some(entry.id.clone());
+                                    }
 
-                                    // タイムスタンプ
-                                    ui.colored_label(
-                                        hint_color,
-                                        egui::RichText::new(&time_str).size(10.0),
+                                    // 区切り線
+                                    ui.painter().line_segment(
+                                        [
+                                            egui::pos2(response.rect.left(), response.rect.bottom()),
+                                            egui::pos2(response.rect.right(), response.rect.bottom()),
+                                        ],
+                                        egui::Stroke::new(0.5, border_color),
                                     );
 
-                                    ui.add_space(4.0);
+                                    // キーボード選択時に自動スクロール
+                                    if is_selected && scroll_to_index >= 0 {
+                                        response.scroll_to_me(Some(egui::Align::Center));
+                                    }
+                                }
 
-                                    // プレビュー（折り返さず1行で）
-                                    let preview = if entry.preview.len() > 80 {
-                                        format!(
-                                            "{}...",
-                                            entry.preview.chars().take(80).collect::<String>()
+                                // ページャー: 「...see more」
+                                if self.has_more_pages() {
+                                    ui.add_space(8.0);
+                                    let see_more = ui.add(
+                                        egui::Label::new(
+                                            egui::RichText::new(format!(
+                                                "...see more ({} remaining)",
+                                                self.total_matches
+                                                    - (self.current_page + 1) * ITEMS_PER_PAGE
+                                            ))
+                                            .size(12.0)
+                                            .color(accent_color),
                                         )
-                                    } else {
-                                        entry.preview.clone()
-                                    };
+                                        .sense(egui::Sense::click()),
+                                    );
 
-                                    // 選択中は太字で表示
-                                    let text = if is_selected {
-                                        egui::RichText::new(preview).size(12.0).strong().color(fg_color)
-                                    } else {
-                                        egui::RichText::new(preview).size(12.0).color(fg_color)
-                                    };
-                                    ui.label(text);
-                                })
-                                .response;
+                                    if see_more.clicked() {
+                                        self.current_page += 1;
+                                        self.refresh_results();
+                                    }
 
-                            // 選択中 or ホバー時の背景
-                            if is_selected {
-                                // 選択行: 強調背景 + 左ボーダー
-                                ui.painter().rect_filled(
-                                    response.rect,
-                                    2.0,
-                                    selected_color,
-                                );
-                                // 左側にアクセントカラーのバー
-                                let bar_rect = egui::Rect::from_min_size(
-                                    response.rect.left_top(),
-                                    egui::vec2(3.0, response.rect.height()),
-                                );
-                                ui.painter().rect_filled(bar_rect, 1.0, selected_border_color);
-                            } else if response.hovered() {
-                                ui.painter().rect_filled(
-                                    response.rect,
-                                    2.0,
-                                    hover_color,
-                                );
-                            }
+                                    if see_more.hovered() {
+                                        ui.output_mut(|o| {
+                                            o.cursor_icon = egui::CursorIcon::PointingHand;
+                                        });
+                                    }
+                                }
 
-                            // クリックで選択 → コピー
-                            if response.clicked() {
-                                self.selected_entry_id = Some(entry.id.clone());
-                            }
-
-                            // 区切り線
-                            ui.painter().line_segment(
-                                [
-                                    egui::pos2(response.rect.left(), response.rect.bottom()),
-                                    egui::pos2(response.rect.right(), response.rect.bottom()),
-                                ],
-                                egui::Stroke::new(0.5, border_color),
-                            );
-
-                            // キーボード選択時に自動スクロール
-                            if is_selected && scroll_to_index >= 0 {
-                                response.scroll_to_me(Some(egui::Align::Center));
-                            }
-                        }
-
-                        // ページャー: 「...see more」
-                        if self.has_more_pages() {
-                            ui.add_space(8.0);
-                            let see_more = ui.add(
-                                egui::Label::new(
-                                    egui::RichText::new(format!(
-                                        "...see more ({} remaining)",
-                                        self.total_matches
-                                            - (self.current_page + 1) * ITEMS_PER_PAGE
-                                    ))
-                                    .size(12.0)
-                                    .color(accent_color),
-                                )
-                                .sense(egui::Sense::click()),
-                            );
-
-                            if see_more.clicked() {
-                                self.current_page += 1;
-                                self.refresh_results();
-                            }
-
-                            if see_more.hovered() {
-                                ui.output_mut(|o| {
-                                    o.cursor_icon = egui::CursorIcon::PointingHand;
-                                });
-                            }
-                        }
-
-                        // 結果なし
-                        if self.display_entries.is_empty() && !self.search_query.is_empty() {
-                            ui.add_space(20.0);
-                            ui.colored_label(
-                                hint_color,
-                                egui::RichText::new("検索結果がありません").size(14.0),
-                            );
-                        } else if self.display_entries.is_empty() {
-                            ui.add_space(20.0);
-                            ui.colored_label(
-                                hint_color,
-                                egui::RichText::new(
-                                    "クリップボード履歴はまだありません\nテキストや画像をコピーすると自動的に記録されます",
-                                )
-                                .size(13.0),
-                            );
-                        }
+                                // 結果なし
+                                if self.display_entries.is_empty() && !self.search_query.is_empty() {
+                                    ui.add_space(20.0);
+                                    ui.colored_label(
+                                        hint_color,
+                                        egui::RichText::new("検索結果がありません").size(14.0),
+                                    );
+                                } else if self.display_entries.is_empty() {
+                                    ui.add_space(20.0);
+                                    ui.colored_label(
+                                        hint_color,
+                                        egui::RichText::new(
+                                            "履歴なし\nコピーすると自動記録",
+                                        )
+                                        .size(13.0),
+                                    );
+                                }
+                            });
                     });
+
+                    // --- 中央の区切り線 ---
+                    let divider_rect = ui.available_rect_before_wrap();
+                    ui.painter().line_segment(
+                        [
+                            egui::pos2(divider_rect.left(), divider_rect.top()),
+                            egui::pos2(divider_rect.left(), divider_rect.bottom()),
+                        ],
+                        egui::Stroke::new(1.0, panel_divider_color),
+                    );
+                    ui.add_space(8.0);
+
+                    // --- 右パネル: 詳細表示 ---
+                    ui.vertical(|ui| {
+                        self.render_detail_panel(ui, ctx);
+                    });
+                });
             });
 
         // 常にリペイント（検索変更の即時反映用）
@@ -419,7 +640,7 @@ impl eframe::App for ClipboardHistoryPopup {
 pub fn show_clipboard_history(store: SharedStore) -> Result<(), Box<dyn std::error::Error>> {
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
-            .with_inner_size([600.0, 500.0])
+            .with_inner_size([1100.0, 600.0])
             .with_decorations(false)
             .with_always_on_top()
             .with_transparent(true)
@@ -444,7 +665,9 @@ pub fn show_clipboard_history(store: SharedStore) -> Result<(), Box<dyn std::err
     Ok(())
 }
 
-// --- ヘルパー ---
+// =============================================================================
+// ヘルパー関数
+// =============================================================================
 
 #[cfg(windows)]
 fn is_current_process_foreground() -> bool {
@@ -499,3 +722,353 @@ fn setup_japanese_fonts(ctx: &egui::Context) {
         }
     }
 }
+
+/// サイズを人間可読な文字列に変換
+fn format_size(bytes: usize) -> String {
+    if bytes < 1024 {
+        format!("{} B", bytes)
+    } else if bytes < 1024 * 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+/// PNGデータをデコードし、大きな画像はリサイズしてRGBA8バッファを返す。
+///
+/// 戻り値: (幅, 高さ, RGBAバイト列)。デコード失敗時はErrを返す。
+fn decode_and_resize_png(png_data: &[u8]) -> Result<(u32, u32, Vec<u8>), String> {
+    let img = image::load_from_memory_with_format(png_data, image::ImageFormat::Png)
+        .map_err(|e| format!("PNG デコード失敗: {}", e))?;
+
+    const MAX_TEXTURE_DIM: u32 = 1024;
+    let img = if img.width() > MAX_TEXTURE_DIM || img.height() > MAX_TEXTURE_DIM {
+        img.resize(MAX_TEXTURE_DIM, MAX_TEXTURE_DIM, image::imageops::FilterType::Triangle)
+    } else {
+        img
+    };
+
+    let rgba = img.to_rgba8();
+    let (w, h) = (rgba.width(), rgba.height());
+
+    if w == 0 || h == 0 {
+        return Err(format!("画像サイズが0: {}x{}", w, h));
+    }
+
+    Ok((w, h, rgba.into_raw()))
+}
+
+/// 画像の表示サイズを計算する（アスペクト比維持、利用可能領域にフィット）。
+///
+/// - `tex_w`, `tex_h`: テクスチャの元サイズ
+/// - `available_w`, `available_h`: 利用可能な描画領域（ヘッダー余白差し引き前の生値）
+///
+/// 戻り値: (表示幅, 表示高さ)。常に正の値を返す。
+fn calculate_image_display_size(tex_w: f32, tex_h: f32, available_w: f32, available_h: f32) -> (f32, f32) {
+    let avail_w = available_w.max(1.0);
+    let avail_h = (available_h - 30.0).max(1.0); // ヘッダー分の余白
+
+    let scale = (avail_w / tex_w.max(1.0)).min(avail_h / tex_h.max(1.0)).max(0.01);
+
+    (tex_w * scale, tex_h * scale)
+}
+
+// =============================================================================
+// テスト
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // format_size のユニットテスト
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_format_size_bytes() {
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(512), "512 B");
+        assert_eq!(format_size(1023), "1023 B");
+    }
+
+    #[test]
+    fn test_format_size_kb() {
+        assert_eq!(format_size(1024), "1.0 KB");
+        assert_eq!(format_size(1536), "1.5 KB");
+        assert_eq!(format_size(1024 * 1023), "1023.0 KB");
+    }
+
+    #[test]
+    fn test_format_size_mb() {
+        assert_eq!(format_size(1024 * 1024), "1.0 MB");
+        assert_eq!(format_size(11 * 1024 * 1024), "11.0 MB");
+    }
+
+    // -------------------------------------------------------------------------
+    // calculate_image_display_size のユニットテスト
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_calc_display_size_normal_landscape() {
+        // 横長画像 800x400 を 600x400 領域に表示
+        let (w, h) = calculate_image_display_size(800.0, 400.0, 600.0, 430.0);
+        // avail_h = 430-30 = 400, scale = min(600/800, 400/400) = min(0.75, 1.0) = 0.75
+        assert!((w - 600.0).abs() < 0.1);
+        assert!((h - 300.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_calc_display_size_normal_portrait() {
+        // 縦長画像 400x800 を 600x430 領域に表示
+        let (w, h) = calculate_image_display_size(400.0, 800.0, 600.0, 430.0);
+        // avail_h = 400, scale = min(600/400, 400/800) = min(1.5, 0.5) = 0.5
+        assert!((w - 200.0).abs() < 0.1);
+        assert!((h - 400.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_calc_display_size_square() {
+        let (w, h) = calculate_image_display_size(500.0, 500.0, 300.0, 330.0);
+        // avail_h = 300, scale = min(300/500, 300/500) = 0.6
+        assert!((w - 300.0).abs() < 0.1);
+        assert!((h - 300.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_calc_display_size_negative_available_height() {
+        // BUG-1 の再現: available_h が 30 未満 → avail_h が負になっていた
+        let (w, h) = calculate_image_display_size(100.0, 100.0, 50.0, 10.0);
+        // avail_h = max(10-30, 1) = 1, avail_w = 50
+        // scale = min(50/100, 1/100) = 0.01
+        assert!(w > 0.0, "幅は正であること: {}", w);
+        assert!(h > 0.0, "高さは正であること: {}", h);
+    }
+
+    #[test]
+    fn test_calc_display_size_zero_available() {
+        let (w, h) = calculate_image_display_size(100.0, 100.0, 0.0, 0.0);
+        assert!(w > 0.0);
+        assert!(h > 0.0);
+    }
+
+    #[test]
+    fn test_calc_display_size_negative_available() {
+        let (w, h) = calculate_image_display_size(100.0, 100.0, -50.0, -20.0);
+        assert!(w > 0.0);
+        assert!(h > 0.0);
+    }
+
+    #[test]
+    fn test_calc_display_size_very_large_texture() {
+        // 巨大テクスチャを小さい領域に表示
+        let (w, h) = calculate_image_display_size(4000.0, 3000.0, 400.0, 330.0);
+        assert!(w <= 400.0 + 0.1);
+        assert!(h <= 300.0 + 0.1);
+        assert!(w > 0.0);
+        assert!(h > 0.0);
+    }
+
+    #[test]
+    fn test_calc_display_size_tiny_texture() {
+        // 1x1 テクスチャ
+        let (w, h) = calculate_image_display_size(1.0, 1.0, 600.0, 430.0);
+        assert!(w > 0.0);
+        assert!(h > 0.0);
+    }
+
+    #[test]
+    fn test_calc_display_size_zero_texture() {
+        // テクスチャサイズ 0 （ガード: max(1.0)で除算保護）
+        let (w, h) = calculate_image_display_size(0.0, 0.0, 600.0, 430.0);
+        assert!(w.is_finite());
+        assert!(h.is_finite());
+    }
+
+    // -------------------------------------------------------------------------
+    // decode_and_resize_png のユニットテスト
+    // -------------------------------------------------------------------------
+
+    /// テスト用の最小限の有効なPNGを生成する（clipboard_historyのencode関数に依存しない）
+    fn create_test_png(width: u32, height: u32) -> Vec<u8> {
+        use image::{ImageBuffer, Rgba};
+        let img: ImageBuffer<Rgba<u8>, Vec<u8>> =
+            ImageBuffer::from_fn(width, height, |x, y| {
+                Rgba([(x % 256) as u8, (y % 256) as u8, 128, 255])
+            });
+        let mut buf = Vec::new();
+        let mut cursor = std::io::Cursor::new(&mut buf);
+        img.write_to(&mut cursor, image::ImageFormat::Png).unwrap();
+        buf
+    }
+
+    #[test]
+    fn test_decode_valid_small_png() {
+        let png = create_test_png(4, 4);
+        let result = decode_and_resize_png(&png);
+        assert!(result.is_ok());
+        let (w, h, rgba) = result.unwrap();
+        assert_eq!(w, 4);
+        assert_eq!(h, 4);
+        assert_eq!(rgba.len(), 4 * 4 * 4); // RGBA
+    }
+
+    #[test]
+    fn test_decode_1x1_png() {
+        let png = create_test_png(1, 1);
+        let (w, h, rgba) = decode_and_resize_png(&png).unwrap();
+        assert_eq!(w, 1);
+        assert_eq!(h, 1);
+        assert_eq!(rgba.len(), 4);
+    }
+
+    #[test]
+    fn test_decode_invalid_data_returns_err() {
+        let result = decode_and_resize_png(b"not a png");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("デコード失敗"));
+    }
+
+    #[test]
+    fn test_decode_empty_data_returns_err() {
+        let result = decode_and_resize_png(b"");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decode_truncated_png_returns_err() {
+        let png = create_test_png(4, 4);
+        // PNGヘッダーだけ残して切り詰め
+        let truncated = &png[..8];
+        let result = decode_and_resize_png(truncated);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decode_large_image_gets_resized() {
+        // 2048x1536 → 最大辺 1024 にリサイズされるはず
+        let png = create_test_png(2048, 1536);
+        let (w, h, _) = decode_and_resize_png(&png).unwrap();
+        assert!(w <= 1024, "幅が1024以下: {}", w);
+        assert!(h <= 1024, "高さが1024以下: {}", h);
+        // アスペクト比が維持されること
+        let ratio_orig = 2048.0 / 1536.0;
+        let ratio_resized = w as f64 / h as f64;
+        assert!((ratio_orig - ratio_resized).abs() < 0.05, "アスペクト比維持: {} vs {}", ratio_orig, ratio_resized);
+    }
+
+    #[test]
+    fn test_decode_exact_1024_not_resized() {
+        let png = create_test_png(1024, 768);
+        let (w, h, _) = decode_and_resize_png(&png).unwrap();
+        assert_eq!(w, 1024);
+        assert_eq!(h, 768);
+    }
+
+    #[test]
+    fn test_decode_just_over_1024_gets_resized() {
+        let png = create_test_png(1025, 512);
+        let (w, h, _) = decode_and_resize_png(&png).unwrap();
+        assert!(w <= 1024);
+        assert!(h <= 1024);
+    }
+
+    #[test]
+    fn test_decode_rgba_buffer_size_matches() {
+        let png = create_test_png(100, 50);
+        let (w, h, rgba) = decode_and_resize_png(&png).unwrap();
+        assert_eq!(rgba.len(), (w * h * 4) as usize);
+    }
+
+    // -------------------------------------------------------------------------
+    // 結合テスト: PNGファイルの読み書き + デコード + サイズ計算の一連の流れ
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_integration_png_file_decode_and_display_size() {
+        // 1. テスト用PNGファイルを一時ディレクトリに作成
+        let dir = tempfile::tempdir().unwrap();
+        let png_path = dir.path().join("test_image.png");
+        let png_data = create_test_png(800, 600);
+        std::fs::write(&png_path, &png_data).unwrap();
+
+        // 2. ファイルから読み込み + デコード
+        let loaded = std::fs::read(&png_path).unwrap();
+        let (w, h, rgba) = decode_and_resize_png(&loaded).unwrap();
+        assert_eq!(w, 800);
+        assert_eq!(h, 600);
+        assert_eq!(rgba.len(), (800 * 600 * 4) as usize);
+
+        // 3. 表示サイズ計算（1100x600 のウィンドウ右55%パネル相当）
+        let (dw, dh) = calculate_image_display_size(w as f32, h as f32, 605.0, 500.0);
+        assert!(dw > 0.0 && dw <= 605.0);
+        assert!(dh > 0.0 && dh <= 470.0); // 500 - 30 = 470
+    }
+
+    #[test]
+    fn test_integration_large_png_file_resize_and_display() {
+        // 大きなPNG → リサイズ → 表示サイズ計算の一連フロー
+        let dir = tempfile::tempdir().unwrap();
+        let png_path = dir.path().join("large_image.png");
+        let png_data = create_test_png(2000, 1500);
+        std::fs::write(&png_path, &png_data).unwrap();
+
+        let loaded = std::fs::read(&png_path).unwrap();
+        let (w, h, rgba) = decode_and_resize_png(&loaded).unwrap();
+
+        // リサイズされて1024以下になること
+        assert!(w <= 1024);
+        assert!(h <= 1024);
+        assert_eq!(rgba.len(), (w * h * 4) as usize);
+
+        // 表示サイズは正の値
+        let (dw, dh) = calculate_image_display_size(w as f32, h as f32, 605.0, 500.0);
+        assert!(dw > 0.0);
+        assert!(dh > 0.0);
+    }
+
+    #[test]
+    fn test_integration_corrupt_file_graceful_error() {
+        // 壊れたファイル → デコードエラーが返る（パニックしない）
+        let dir = tempfile::tempdir().unwrap();
+        let corrupt_path = dir.path().join("corrupt.png");
+        std::fs::write(&corrupt_path, b"this is not a valid PNG file").unwrap();
+
+        let loaded = std::fs::read(&corrupt_path).unwrap();
+        let result = decode_and_resize_png(&loaded);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_integration_missing_file_io_error() {
+        // 存在しないファイル → fs::read がエラー
+        let result = std::fs::read("/nonexistent/path/image.png");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_integration_bug1_scenario_negative_size_no_panic() {
+        // BUG-1 の再現シナリオ: 画像デコード成功 → 表示サイズ計算で負の値
+        let png = create_test_png(1920, 1080);
+        let (w, h, _) = decode_and_resize_png(&png).unwrap();
+
+        // 初期フレーム等で利用可能領域がほぼゼロのケース
+        let scenarios: Vec<(f32, f32)> = vec![
+            (0.0, 0.0),       // ゼロ
+            (-5.0, -3.0),     // 負の値
+            (10.0, 20.0),     // ヘッダー(30px)より小さい → avail_h が負になっていた
+            (1.0, 1.0),       // 極小
+            (100.0, 29.0),    // avail_h = max(29-30, 1) = 1
+            (0.5, 0.5),       // 1未満
+        ];
+
+        for (avail_w, avail_h) in scenarios {
+            let (dw, dh) = calculate_image_display_size(w as f32, h as f32, avail_w, avail_h);
+            assert!(dw > 0.0, "avail=({},{}) → dw={} は正であること", avail_w, avail_h, dw);
+            assert!(dh > 0.0, "avail=({},{}) → dh={} は正であること", avail_w, avail_h, dh);
+            assert!(dw.is_finite(), "dw は有限値であること");
+            assert!(dh.is_finite(), "dh は有限値であること");
+        }
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,8 @@ struct CliArgs {
     engine: Option<String>,
     /// --no-tray: トレイモードを使わず直接ポップアップ
     no_tray: bool,
+    /// --clipboard-history: クリップボード履歴ポップアップ（内部用: 別プロセスで起動）
+    clipboard_history: bool,
 }
 
 impl CliArgs {
@@ -59,6 +61,7 @@ impl CliArgs {
             format_result_file: None,
             engine: None,
             no_tray: false,
+            clipboard_history: false,
         };
 
         let mut i = 0;
@@ -106,6 +109,9 @@ impl CliArgs {
                 "--no-tray" => {
                     cli.no_tray = true;
                 }
+                "--clipboard-history" => {
+                    cli.clipboard_history = true;
+                }
                 "--help" | "-h" => {
                     println!("Lanch App - 統一ランチャー (翻訳 + Markdown整形)");
                     println!();
@@ -140,7 +146,78 @@ impl CliArgs {
     }
 }
 
+/// ログファイルの初期化
+///
+/// ~/.lanch-app/lanch-app.log に eprintln! の出力をリダイレクトする。
+/// ローテーション: 2日以上前のログは自動削除。サイズが1MB超でも即ローテーション。
+fn init_logging() {
+    let log_dir = dirs::home_dir()
+        .map(|h| h.join(".lanch-app"))
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+
+    let _ = fs::create_dir_all(&log_dir);
+    let log_path = log_dir.join("lanch-app.log");
+    let old_path = log_dir.join("lanch-app.log.old");
+
+    // 2日以上前の .log.old は削除
+    if let Ok(meta) = fs::metadata(&old_path) {
+        if let Ok(modified) = meta.modified() {
+            if let Ok(elapsed) = modified.elapsed() {
+                if elapsed.as_secs() > 2 * 24 * 60 * 60 {
+                    let _ = fs::remove_file(&old_path);
+                }
+            }
+        }
+    }
+
+    // 現行ログが2日以上前 or 1MB超 → ローテーション（古いoldは上で消済み）
+    let should_rotate = if let Ok(meta) = fs::metadata(&log_path) {
+        let too_old = meta.modified().ok().and_then(|m| m.elapsed().ok())
+            .map(|e| e.as_secs() > 2 * 24 * 60 * 60)
+            .unwrap_or(false);
+        too_old || meta.len() > 1_000_000
+    } else {
+        false
+    };
+
+    if should_rotate {
+        let _ = fs::rename(&log_path, &old_path);
+    }
+
+    // ログファイルを追記モードで開いてstderrをリダイレクト
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::IntoRawHandle;
+        use std::fs::OpenOptions;
+
+        if let Ok(file) = OpenOptions::new().create(true).append(true).open(&log_path) {
+            let handle = file.into_raw_handle();
+            unsafe {
+                use windows_sys::Win32::System::Threading::GetCurrentProcess;
+                use windows_sys::Win32::Foundation::HANDLE;
+
+                // SetStdHandle で stderr をログファイルに差し替え
+                // STD_ERROR_HANDLE = -12i32 as u32
+                const STD_ERROR_HANDLE: u32 = (-12i32) as u32;
+                windows_sys::Win32::System::Console::SetStdHandle(
+                    STD_ERROR_HANDLE,
+                    handle as HANDLE,
+                );
+                let _ = GetCurrentProcess(); // suppress unused warning
+            }
+        }
+    }
+
+    // 起動ログ
+    let now = chrono::Local::now();
+    let args: Vec<String> = env::args().collect();
+    eprintln!("\n=== lanch-app started at {} ===", now.format("%Y-%m-%d %H:%M:%S"));
+    eprintln!("  args: {:?}", args);
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+
     let args = CliArgs::parse();
     let mut config = config::load_config();
 
@@ -150,7 +227,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // --- モード分岐 ---
 
-    if let Some(text) = args.translate_text {
+    if args.clipboard_history {
+        // クリップボード履歴ポップアップ（別プロセスで起動される）
+        use std::sync::{Arc, Mutex};
+        let store = clipboard_store::ClipboardStore::new(7);
+        let shared: clipboard_history::SharedStore = Arc::new(Mutex::new(store));
+        clipboard_ui::show_clipboard_history(shared)?;
+    } else if let Some(text) = args.translate_text {
         // CLI翻訳モード
         let result = translator::translate(&text, &config)?;
         println!("{}", result.translated);

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -25,7 +25,6 @@ use std::thread;
 
 use crate::clipboard;
 use crate::clipboard_history;
-use crate::clipboard_ui;
 use crate::config::Config;
 use crate::formatter;
 use crate::notification;
@@ -273,7 +272,7 @@ pub fn run_tray(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // --- クリップボード履歴監視を開始 ---
-    let clipboard_store = clipboard_history::start_monitoring();
+    let _clipboard_store = clipboard_history::start_monitoring();
 
     // --- メニューの作成 ---
     let menu = Menu::new();
@@ -476,13 +475,8 @@ pub fn run_tray(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
                         continue;
                     }
                     last_history_hotkey_time = std::time::Instant::now();
-                    // 別プロセスとして履歴UIを起動
-                    let store_clone = clipboard_store.clone();
-                    thread::spawn(move || {
-                        if let Err(e) = clipboard_ui::show_clipboard_history(store_clone) {
-                            eprintln!("[clipboard_history] UI起動に失敗: {}", e);
-                        }
-                    });
+                    // 別プロセスとして履歴UIを起動（EventLoop再作成エラー回避）
+                    spawn_self(&["--clipboard-history"]);
                 }
             }
 
@@ -495,12 +489,7 @@ pub fn run_tray(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
                 } else if event.id == item_format_id {
                     handle_markdown_format(config);
                 } else if event.id == item_history_id {
-                    let store_clone = clipboard_store.clone();
-                    thread::spawn(move || {
-                        if let Err(e) = clipboard_ui::show_clipboard_history(store_clone) {
-                            eprintln!("[clipboard_history] UI起動に失敗: {}", e);
-                        }
-                    });
+                    spawn_self(&["--clipboard-history"]);
                 } else if event.id == item_quit_id {
                     return Ok(());
                 }


### PR DESCRIPTION
## Summary
- **BUG-1修正**: 画像エントリ選択時の `Negative child size` パニックを解消（サイズ計算ガード + 大画像リサイズ）
- **画像コピー対応**: 画像エントリ選択時にPNGデコードして画像データとしてクリップボードにコピー（旧: ファイルパスをテキストとしてコピーしていた暫定実装）
- **自動ペースト**: Enter/ダブルクリックで選択 → コピー → ウィンドウ閉じ → 元ウィンドウにフォーカス復元 → Ctrl+V 自動ペースト
- **レイアウト修正**: 左右パネルがウィンドウ全高に広がるよう修正
- **テスト+26件** (84→110): 画像デコード・サイズ計算・結合テストを網羅
- **BUG-2対策**: 別プロセス起動方式 (`--clipboard-history`)、ファイルログ出力、選択ハイライト黄色化等を含む

## Test plan
- [x] `cargo test` 110テスト全パス
- [x] `cargo build` warning 0
- [x] 画像エントリ選択時にクラッシュしないこと（手動確認済み）
- [x] 画像エントリ選択 → 画像データとしてクリップボードにコピーされること
- [x] Enter選択 → 元ウィンドウにフォーカス復元 → 自動ペーストされること
- [x] Ctrl+Shift+V 2回目以降の起動が正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)