### PR TITLE
fix(ci): Codecov を実際に動かす (Windows runner + llvm-cov, silent fallback 撲滅)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,26 +6,39 @@ on:
   pull_request:
     branches: [main]
 
+# 同一ブランチで in-flight があればキャンセル
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # lanch-app は Windows 専用デスクトップアプリ（winit::platform::windows、windows_sys を直接利用）
+    # Linux runner ではビルドが通らないため Windows runner を使う
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Rust toolchain (with llvm-tools)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
       - uses: Swatinem/rust-cache@v2
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libxdo-dev
-      - name: Check (allow warnings)
-        run: cargo check 2>&1 || true
-      - name: Run tests
-        run: cargo test 2>&1 || true
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
-      - name: Generate coverage
-        run: cargo tarpaulin --out xml --output-dir . --skip-clean 2>&1 || true
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests with coverage (codecov format)
+        run: cargo llvm-cov --workspace --codecov --output-path codecov.json
+
       - name: Upload coverage to Codecov
-        if: always()
         uses: codecov/codecov-action@v5
         with:
-          files: cobertura.xml
-          fail_ci_if_error: false
+          files: codecov.json
+          fail_ci_if_error: true
+          flags: unittests
+          name: lanch-app-coverage


### PR DESCRIPTION
## 背景

agent-base [Issue #33](https://github.com/miyashita337/agent-base/issues/33) (Epic [#28](https://github.com/miyashita337/agent-base/issues/28)) の Codecov 導入検証中に発覚:

- PR #11 で CI workflow + Codecov upload step は merge 済み
- だが [CI run 24254520423](https://github.com/miyashita337/lanch-app/actions/runs/24254520423) のログを見ると **実際は coverage が一度もアップロードされていなかった**
- Codecov API: `{"active":false,"activated":false,"totals":null}` ← dashboard 一度も活性化していない

### 真因（3 つの silent failure 連鎖）

1. **OS mismatch**: lanch-app は Windows 専用 (`winit::platform::windows::EventLoopBuilderExtWindows`, `windows_sys::Win32::*` を直接利用) なのに CI は `ubuntu-latest` → `cargo tarpaulin` が `error[E0432]: unresolved import 'winit::platform::windows'` で compile fail
2. **Silent fallback の濫用**: `cargo check 2>&1 || true` / `cargo test 2>&1 || true` / `cargo tarpaulin ... || true` の 3 連発で失敗を全部握りつぶす設計だった (agent-base RW: agent-output-quality \"サイレントフォールバックの禁止\" 違反)
3. **Codecov upload も silent fail**: `fail_ci_if_error: false` で `Found 0 coverage files to report` を素通り

結果 CI は緑だが Codecov は空。これでは Codecov 導入の AC「Codecov ダッシュボードでレポート確認」を満たせない。

## 変更内容

| 項目 | Before | After |
|---|---|---|
| runner | ubuntu-latest | **windows-latest** (Windows 専用アプリの実態に合わせる) |
| coverage tool | cargo-tarpaulin (Linux 専用 / ptrace) | **cargo-llvm-cov** (cross-platform / 公式 Rust tooling, インストール高速) |
| coverage 形式 | cobertura.xml 経由 | `--codecov --output-path codecov.json` でネイティブ JSON 直生成 |
| `2>&1 \|\| true` | 4 箇所で握りつぶし | **全削除**。失敗は CI failure として可視化 |
| `fail_ci_if_error` | false | **true** (upload 失敗 = CI 失敗) |
| concurrency | 無し | 追加 (in-flight キャンセル) |
| apt-get install gtk/xdo | あり | 不要 (Windows runner) |

## 統合ジャーニーAC

CI/Codecov 設定のみで、ユーザー視点フローなし (`rules/general/journey-ac.md` の例外条件「ビルド設定・CI 設定のみの変更」「『統合ジャーニーがない』種類のタスク」に該当)。

## コンポーネント AC

| AC-ID | 内容 | 検証 |
|---|---|---|
| AC-1 | windows-latest で `cargo build` が success | CI run の build step 緑 |
| AC-2 | `cargo llvm-cov --workspace --codecov --output-path codecov.json` が success かつ `codecov.json` を生成 | CI run の coverage step 緑 + ファイル生成ログ |
| AC-3 | Codecov upload が success | codecov-action step 緑 + `fail_ci_if_error: true` 下で完走 |
| AC-4 | Codecov dashboard が active になり、coverage % が表示される | https://codecov.io/gh/miyashita337/lanch-app の `activated: true` + `totals.coverage` が非 null |
| AC-5 | サイレントフォールバック (`\|\| true`) が ci.yml から完全消滅 | `grep -c '\|\| true' .github/workflows/ci.yml` == 0 |

## 関連

- agent-base Issue #33 (Codecov 導入: lanch-app)
- agent-base Epic #28 (全リポジトリ Codecov 導入)
- 過去 PR #11 (壊れた状態のまま merge されていた)